### PR TITLE
Use bytes for python3 support

### DIFF
--- a/and_scale_ros/scripts/ekew_i_driver.py
+++ b/and_scale_ros/scripts/ekew_i_driver.py
@@ -64,7 +64,7 @@ class EkEwIDriver(object):
             return
 
         try:
-            self.ser.write('Q\r\n')
+            self.ser.write(b'Q\r\n')
         except SerialTimeoutException:
             rospy.logerr('Serial write timeout')
             rospy.signal_shutdown('Serial write timeout')
@@ -82,18 +82,18 @@ class EkEwIDriver(object):
         header = data[:2]
         msg.weight.value = float(data[3:12])
         unit = data[12:15]
-        if unit == '  g':
-            if header == 'ST':
+        if unit == b'  g':
+            if header == b'ST':
                 # stable
                 msg.weight.stable = True
-            elif header == 'US':
+            elif header == b'US':
                 # unstable
                 msg.weight.stable = False
-            elif header == 'OL':
+            elif header == b'OL':
                 # scale over
                 rospy.logerr('Scale data is over its range')
                 return
-            elif header == 'QT':
+            elif header == b'QT':
                 # number mode
                 rospy.logerr('Scale is in number mode')
                 return


### PR DESCRIPTION

Fixed following error in noetic/python3 environment.
```
[INFO] [1729139694.064560]: port=/dev/ttyUSB0
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/home/leus/hironx_ws/src/jsk_3rdparty/and_scale_ros/scripts/ekew_i_driver.py", line 68, in _read_timer_cb
    self.ser.write('Q\r\n')
  File "/usr/lib/python3/dist-packages/serial/serialposix.py", line 532, in write
    d = to_bytes(data)
  File "/usr/lib/python3/dist-packages/serial/serialutil.py", line 63, in to_bytes
    raise TypeError('unicode strings are not supported, please encode to bytes: {!r}'.format(seq))
TypeError: unicode strings are not supported, please encode to bytes: 'Q\r\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/timer.py", line 237, in run
    self._callback(TimerEvent(last_expected, last_real, current_expected, current_real, last_duration))
  File "/home/leus/hironx_ws/src/jsk_3rdparty/and_scale_ros/scripts/ekew_i_driver.py", line 69, in _read_timer_cb
    except SerialTimeoutException:
NameError: name 'SerialTimeoutException' is not defined
```
